### PR TITLE
Docker関連ファイルの追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,125 @@
+########################
+### .gitignoreを踏襲 
+########################
+
+#credencial file
+config.py
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mypy
+.mypy_cache/
+
+# pickles
+*.pickle
+
+# file
+first_time
+.env-docker
+
+# temp
+temp/
+
+# Log
+Log/
+
+# vscode
+.vscode/
+
+# sqlite3 db
+*.db
+*.bin
+
+# docker
+docker-compose.override.yml
+
+########################
+### .dockerignore only 
+########################
+
+# docker
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ Log/
 # sqlite3 db
 *.db
 *.bin
+
+# docker
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.8-buster as builder
+
+ARG POETRY_VERSION=1.1.13
+ARG POETRY_HOME=/opt/poetry
+
+# poetry導入
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=${POETRY_HOME} python3 - --version=${POETRY_VERSION}
+ENV PATH ${PATH}:${POETRY_HOME}/bin
+
+COPY ./ /app
+WORKDIR /app
+
+RUN poetry install
+
+CMD ["poetry", "run", "python", "discord-reminderbot.py"] 
+VOLUME [ "/app/cogs/modules/files" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+  app:
+    build: .
+    volumes:
+      # DBデータ永続化
+      - "./cogs/modules/files:/app/cogs/modules/files"
+    environment:
+      # docker-compose.override.ymlで上書き定義することを推奨
+      - DISCORD_TOKEN=__ここにDiscordのトークンを書き込む__
+      - LOG_LEVEL=INFO
+      - ENABLE_SLASH_COMMAND_GUILD_ID_LIST= __あなたのGuild_IDを入力(数字/複数あるなら;を挟むこと。グローバルコマンドの場合は入力しないこと！(その場合1時間程度登録に時間がかかる可能性があります))__
+      - KEEP_DECRYPTED_FILE=FALSE
+      - IS_HEROKU=FALSE
+      - IS_REPLIT=FALSE
+      - RESTRICT_ATTACHMENT_FILE=FALSE
+      - PRIORITY_GUILD=__あなたのGuild_IDを入力(数字)__


### PR DESCRIPTION
こちらのReminderをDocker環境(GCP)で運用させていただいているため、せっかくなので成果物を上げさせていただきます。

Dockerの面倒なんて見たくなければ無視してください！

## 機能追加

- Dockerでdiscord-reminderbot を起動できるようにした
 - 開発環境向きのDockerfileではありません 

### docker-composeを用いた起動手順

#### 前提
- `docker`,`docker-compose` コマンドが利用できること


#### 環境変数の設定
.envの準備の代わりに、`docker-compose.override.yml` を作成して環境変数を記載

```yaml
version: "3"

services:
  app:
    environment:
      - DISCORD_TOKEN=__ここにDiscordのトークンを書き込む__
      - LOG_LEVEL=INFO
      - ENABLE_SLASH_COMMAND_GUILD_ID_LIST= __あなたのGuild_IDを入力(数字/複数あるなら;を挟むこと。グローバルコマンドの場合は入力しないこと！(その場合1時間程度登録に時間がかかる可能性があります))__
      - KEEP_DECRYPTED_FILE=FALSE
      - IS_HEROKU=FALSE
      - IS_REPLIT=FALSE
      - RESTRICT_ATTACHMENT_FILE=FALSE
      - PRIORITY_GUILD=__あなたのGuild_IDを入力(数字)__
```

#### 起動・停止操作

```bash
# イメージビルド
docker-compose build

# 起動
docker-compose up -d

# 停止
docker-compose down

# ログ出力
docker-compose logs -f
```

## 備考
- 環境変数(機密情報)を含みやすいファイルがDockerイメージに混入しないよう、.dockerignoreに定義
- イメージサイズ削減の余地はあり(現在1.17GB程度)
  - ベースイメージの選定等
- DBデータ(sqlite)が保管されるフォルダ`cogs/modules/files`はdocker volumeにより永続化必須


## 機能改善
- aaa

## バグ修正
- aaa

## その他
### メッセージ見直し
- aaa

## 関連するIssue
- aaa
