### PR TITLE
DockerBuildが失敗する現象への対応(poetryインストールエラー)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG POETRY_VERSION=1.1.13
 ARG POETRY_HOME=/opt/poetry
 
 # poetry導入
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=${POETRY_HOME} python3 - --version=${POETRY_VERSION}
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=${POETRY_HOME} python3 - --version=${POETRY_VERSION}
 ENV PATH ${PATH}:${POETRY_HOME}/bin
 
 COPY ./ /app


### PR DESCRIPTION

## 機能追加

## 機能改善

## バグ修正
poetry 1.2.0 のリリースと同時に旧来のインストーラーが非推奨/非公開となり、
DockerBuild中に404エラーが発生するようになっていました。

現行提供のpoetryインストーラーに切り替えました
(poetryのバージョン自体は変更していません)

### 参考
- https://zenn.dev/hibiki_kato/articles/a663c89477085d
- https://python-poetry.org/blog/announcing-poetry-1.2.0/

### 動作テスト
- `docker compose build` が完了すること
- `docker compose up` でアプリが動作すること(Windows11 (WSL2+DockerDesktop) にて確認)

## その他
### メッセージ見直し


## 関連するIssue
