### PR TITLE
fix: /remind-make で repeat_max_count が str で渡される TypeError を修正

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,48 @@
+name: Docker Publish
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-pyonkity-fork,onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: Extract metadata (tags, labels)
         id: meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-buster as builder
 
-ARG POETRY_VERSION=1.1.13
+ARG POETRY_VERSION=1.8.4
 ARG POETRY_HOME=/opt/poetry
 
 # poetry導入

--- a/cogs/remindercog.py
+++ b/cogs/remindercog.py
@@ -375,6 +375,8 @@ class ReminderCog(commands.Cog):
                         noreply: Literal['返信しない'] = None,
                         reply_is_hidden: Literal['自分のみ', '全員に見せる'] = SHOW_ME):
         LOG.info('remindをmakeするぜ！')
+        if repeat_max_count is not None:
+            repeat_max_count = int(repeat_max_count)
         hidden = True if reply_is_hidden == self.SHOW_ME else False
         silent_mode = True if silent != self.NOT_SILENT else False
         self.check_printer_is_running()


### PR DESCRIPTION
## 概要

`/remind-make` コマンドで `repeat_max_count` を指定すると以下のエラーが発生し、レスポンスが返らない問題を修正。

```
TypeError: '>' not supported between instances of 'str' and 'int'
```

## 原因

`discord.py 2.4.0 → 2.6.3` へのアップデート（#4759069）後、`app_commands.Range[int, 1, 999]` の型変換（transformer）が機能しなくなり、Discord API から渡された値が `str` のまま callback に届くようになった。

`remindercog.py:407` で `repeat_max_count > 5`（`str` vs `int`）の比較が発生し TypeError となっていた。

## 修正内容

関数冒頭で `repeat_max_count` を明示的に `int()` へキャストすることで、discord.py のバージョンに依存しない形に対処。

```python
if repeat_max_count is not None:
    repeat_max_count = int(repeat_max_count)
```

## 再現コマンド

```
/remind-make date: 7/1 time: 8:20 message: テスト repeat_interval: 2mi repeat_max_count: 2
```

## Test plan

- [ ] `/remind-make` で `repeat_max_count` を指定してリマインド登録できること
- [ ] `repeat_interval` が `XXmi` 形式かつ `repeat_max_count > 5` の場合にエラーメッセージが返ること
- [ ] `repeat_max_count` を省略した場合も正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)