### PR TITLE
fix: /remind-make で repeat_max_count が str で渡される TypeError を修正

### DIFF
--- a/cogs/remindercog.py
+++ b/cogs/remindercog.py
@@ -375,6 +375,8 @@ class ReminderCog(commands.Cog):
                         noreply: Literal['返信しない'] = None,
                         reply_is_hidden: Literal['自分のみ', '全員に見せる'] = SHOW_ME):
         LOG.info('remindをmakeするぜ！')
+        if repeat_max_count is not None:
+            repeat_max_count = int(repeat_max_count)
         hidden = True if reply_is_hidden == self.SHOW_ME else False
         silent_mode = True if silent != self.NOT_SILENT else False
         self.check_printer_is_running()


### PR DESCRIPTION
## 概要

`/remind-make` コマンドで `repeat_max_count` を指定すると以下のエラーが発生し、レスポンスが返らない問題を修正します。

```
TypeError: '>' not supported between instances of 'str' and 'int'
```

## 原因

discord.py **2.4.0 → 2.6.3** アップデート後、`app_commands.Range[int, 1, 999]` の型変換（transformer）が機能しなくなり、Discord API から渡された値が `str` のまま callback に届くようになりました。

`remindercog.py` の以下の比較で `str` vs `int` の TypeError が発生していました。

```python
# repeat_max_count が str のまま届くため TypeError
repeat_max_count > 5
```

## 修正内容

関数冒頭で `repeat_max_count` を明示的に `int()` へキャストします。

```python
if repeat_max_count is not None:
    repeat_max_count = int(repeat_max_count)
```

これにより discord.py のバージョンに依存しない動作になります。

## 再現コマンド

```
/remind-make date: 7/1 time: 8:20 message: テスト repeat_interval: 2mi repeat_max_count: 2
```

## Test plan

- [x] `repeat_max_count` を指定してリマインド登録できること
- [x] `repeat_interval` が `XXmi` かつ `repeat_max_count > 5` のときエラーメッセージが返ること
- [x] `repeat_max_count` を省略した場合も正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)